### PR TITLE
Solve Dependency Resolution Problem for Java 8

### DIFF
--- a/Formula/apache-spark@2.3.2.rb
+++ b/Formula/apache-spark@2.3.2.rb
@@ -8,7 +8,7 @@ class ApacheSparkAT232 < Formula
 
   bottle :unneeded
 
-  depends_on :java => "1.8"
+  depends_on "openjdk@8"
 
   def install
     # Rename beeline to distinguish it from hive's beeline

--- a/Formula/apache-spark@2.3.4.rb
+++ b/Formula/apache-spark@2.3.4.rb
@@ -8,7 +8,7 @@ class ApacheSparkAT234 < Formula
 
   bottle :unneeded
 
-  depends_on :java => "1.8"
+  depends_on "openjdk@8"
 
   def install
     # Rename beeline to distinguish it from hive's beeline


### PR DESCRIPTION
This PR proposes replacing the deprecated `depends_on :java => "1.8"` with the appropriate `openjdk` version.